### PR TITLE
Add function getFullError

### DIFF
--- a/src/YperException.php
+++ b/src/YperException.php
@@ -35,4 +35,12 @@ class YperException extends Exception {
         return $this->status;
     }
 
+    public function getFullError() {
+        return [
+            "code" => $this->yper_code,
+            "message" => $this->yper_message,
+            "status" => $this->status
+        ];
+    }
+
 }


### PR DESCRIPTION
Lié à [ce ticket](https://linear.app/yper-product/issue/WEB-757/creation-dun-tag-vol).

# Description
D'une manière plus générale, cette PR ajoute la fonction `getFullError()` qui permet de retourner plus d'informations à la fois sur l'erreur retournée par l'API.